### PR TITLE
Fixed typo in Contributor functionality

### DIFF
--- a/lib/opds-parser.js
+++ b/lib/opds-parser.js
@@ -254,7 +254,7 @@ function handleEntry (node) {
             })
           })
         } else {
-          getContributor(o, function(contributor) {
+          getContributor(el, function(contributor) {
             entry.contributors.push(contributor);
           })
         }


### PR DESCRIPTION
Variable 'o' is not available in this scope, object 'el' seems to be the correct one and works in my testing.